### PR TITLE
matches destructuring syntax adopted by rails

### DIFF
--- a/lib/translator.rb
+++ b/lib/translator.rb
@@ -283,7 +283,7 @@ module Translator::ActionViewExtensions #:nodoc:
       Translator.translate_with_scope(scope, key, options.merge({:raise => true}))
     rescue Translator::TranslatorError, I18n::MissingTranslationData => exc
       # Call the original translate method
-      str = super(key, options)
+      str = super(key, **options)
       
       # View helper adds the translation missing span like:
       # In strict mode, do not allow TranslationHelper to add "translation missing" span like:


### PR DESCRIPTION
A commit 3 years ago in actionview/lib/action_view/helpers/translation_helper.rb

Changed the method signature of translate from
def translate(key, options = {})
to
def translate(key, **options)

See: [rails/rails: 6c02fee](https://github.com/rails/rails/commit/6c02fee08fb15d591f653e855fa62a82af17b892#diff-9c5e802c729a438537b41a02f0b08eb594855d8bebcd0ff2e3452fc6a999375d)

The syntax change seems largely backwards compatible except for calls to super.